### PR TITLE
Prepare 1.0.2 reader UX and image reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: sdkmanager "platforms;android-35" "build-tools;35.0.0"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test, lint, and build debug APK
+        shell: bash
+        run: |
+          chmod +x gradlew
+          ./gradlew testDebugUnitTest lintDebug assembleDebug --no-daemon -Pkotlin.incremental=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Semantic release tag, for example v1.0.0"
+        description: "Semantic release tag, for example v1.0.2"
         required: true
-        default: "v1.0.0"
+        default: "v1.0.2"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ app/build/outputs/apk/release/app-release.apk
 `.github/workflows/release.yml` 会在推送 `v*` 标签时执行测试、Lint、签名构建、`apksigner` 验证，并发布 APK 与 SHA-256 校验文件：
 
 ```powershell
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.0.2
+git push origin v1.0.2
 ```
 
 也可以在 GitHub Actions 页面手动运行 `Android Release` 并填写版本标签。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "io.github.jiangyuyi.lightnovel"
         minSdk = 26
         targetSdk = 35
-        versionCode = providers.environmentVariable("APP_VERSION_CODE").orNull?.toIntOrNull() ?: 1
-        versionName = providers.environmentVariable("APP_VERSION_NAME").orNull ?: "1.0.0"
+        versionCode = providers.environmentVariable("APP_VERSION_CODE").orNull?.toIntOrNull() ?: 3
+        versionName = providers.environmentVariable("APP_VERSION_NAME").orNull ?: "1.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/MainActivity.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/MainActivity.kt
@@ -3,6 +3,7 @@ package io.github.jiangyuyi.lightnovel
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -12,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -98,7 +100,7 @@ private fun LightNovelApp() {
         NavHost(
             navController = navController,
             startDestination = Routes.DISCOVER,
-            modifier = Modifier.padding(padding),
+            modifier = Modifier.padding(if (currentRoute == Routes.READER) PaddingValues(0.dp) else padding),
         ) {
             composable(Routes.DISCOVER) {
                 val vm: DiscoverViewModel = viewModel(factory = viewModelFactory { DiscoverViewModel(container.repository) })
@@ -177,4 +179,3 @@ private fun NavHostController.openRoot(route: String) {
         restoreState = true
     }
 }
-

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/core/data/ChapterNavigation.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/core/data/ChapterNavigation.kt
@@ -1,0 +1,20 @@
+package io.github.jiangyuyi.lightnovel.core.data
+
+import io.github.jiangyuyi.lightnovel.core.model.ChapterSummary
+
+internal data class ChapterNeighbors(
+    val previousChapterId: Long?,
+    val nextChapterId: Long?,
+)
+
+internal fun resolveChapterNeighbors(
+    chapters: List<ChapterSummary>,
+    currentChapterId: Long,
+): ChapterNeighbors? {
+    val currentIndex = chapters.indexOfFirst { it.id == currentChapterId }
+    if (currentIndex < 0) return null
+    return ChapterNeighbors(
+        previousChapterId = chapters.getOrNull(currentIndex - 1)?.id,
+        nextChapterId = chapters.getOrNull(currentIndex + 1)?.id,
+    )
+}

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/core/data/LightNovelRepository.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/core/data/LightNovelRepository.kt
@@ -220,7 +220,52 @@ class LightNovelRepository(
             "api/new-content-read/get-chapter-detail",
             withOptionalSession("book_id" to bookId, "chapter_id" to chapterId),
         )
-        return ApiParsers.chapterDetail(data)
+        val detail = ApiParsers.chapterDetail(data)
+        if (detail.previousChapterId != null && detail.nextChapterId != null) return detail
+        return runCatching { completeChapterNavigation(bookId, detail) }.getOrDefault(detail)
+    }
+
+    private suspend fun completeChapterNavigation(bookId: Long, detail: ChapterDetail): ChapterDetail {
+        val volumeId = detail.chapter.volumeId.takeIf { it > 0 } ?: return detail
+        val volumeChapters = allChapters(bookId, volumeId)
+        val neighbors = resolveChapterNeighbors(volumeChapters, detail.chapter.id) ?: return detail
+        var previousId = detail.previousChapterId ?: neighbors.previousChapterId
+        var nextId = detail.nextChapterId ?: neighbors.nextChapterId
+
+        if (previousId == null || nextId == null) {
+            val bookVolumes = allVolumes(bookId)
+            val volumeIndex = bookVolumes.indexOfFirst { it.id == volumeId }
+            if (previousId == null && volumeIndex > 0) {
+                val previousVolume = bookVolumes[volumeIndex - 1]
+                previousId = previousVolume.lastChapterId
+                    ?: allChapters(bookId, previousVolume.id).lastOrNull()?.id
+            }
+            if (nextId == null && volumeIndex >= 0 && volumeIndex < bookVolumes.lastIndex) {
+                val nextVolume = bookVolumes[volumeIndex + 1]
+                nextId = nextVolume.firstChapterId
+                    ?: allChapters(bookId, nextVolume.id).firstOrNull()?.id
+            }
+        }
+
+        return detail.copy(previousChapterId = previousId, nextChapterId = nextId)
+    }
+
+    private suspend fun allVolumes(bookId: Long): List<Volume> = buildList {
+        var page = 1
+        do {
+            val result = volumes(bookId, page = page, pageSize = 50)
+            addAll(result.items)
+            page += 1
+        } while (result.hasMore)
+    }
+
+    private suspend fun allChapters(bookId: Long, volumeId: Long): List<ChapterSummary> = buildList {
+        var page = 1
+        do {
+            val result = chapters(bookId, volumeId, page = page, pageSize = 50)
+            addAll(result.items)
+            page += 1
+        } while (result.hasMore)
     }
 
     suspend fun bookshelf(): List<BookSummary> {

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/core/network/CronetHttpTransport.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/core/network/CronetHttpTransport.kt
@@ -1,7 +1,11 @@
 package io.github.jiangyuyi.lightnovel.core.network
 
 import android.content.Context
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import org.chromium.net.CronetEngine
 import org.chromium.net.CronetException
 import org.chromium.net.ExperimentalCronetEngine
@@ -39,30 +43,32 @@ internal class CronetHttpTransport(context: Context) : HttpTransport {
         Thread(runnable, "lightnovel-cronet").apply { isDaemon = true }
     }
 
-    @Volatile
-    private var routeIndex = 0
+    private val engines = mutableMapOf<NetworkRoute, CronetEngine>()
 
-    @Volatile
-    private var engine: CronetEngine = createEngine(CLOUDFLARE_ROUTES[routeIndex])
-
-    private fun createEngine(route: String): CronetEngine =
+    private fun createEngine(route: NetworkRoute): CronetEngine =
         ExperimentalCronetEngine.Builder(applicationContext).run {
         enableQuic(true)
         enableHttp2(true)
         enableBrotli(true)
-        // The mainland route resets TCP connections to these hosts on some networks.
-        // Both hosts serve HTTP/3, so try QUIC immediately instead of waiting for Alt-Svc.
+        // Mainland TCP routes to these hosts are unreliable on some networks. Try
+        // QUIC immediately, but let system DNS follow the site's current CDN first.
         addQuicHint("www.lightnovel.fun", 443, 443)
         addQuicHint("api.lightnovel.fun", 443, 443)
         addQuicHint("res.lightnovel.fun", 443, 443)
-        // Some mainland resolvers return a TCP-only compatibility CDN that resets
-        // non-browser clients. Map API and image hosts to their public
-        // Cloudflare anycast edge; the QUIC hints above preserve SNI and TLS checks.
-        setExperimentalOptions(
-            """{"HostResolverRules":{"host_resolver_rules":"MAP www.lightnovel.fun $route, MAP api.lightnovel.fun $route, MAP res.lightnovel.fun $route"}}""",
-        )
+        // These legacy Cloudflare routes are fallbacks only. The site currently
+        // resolves through another CDN, so forcing them for every request causes
+        // image TLS handshakes to be reset while the same URL works in a browser.
+        route.address?.let { address ->
+            setExperimentalOptions(
+                """{"HostResolverRules":{"host_resolver_rules":"MAP www.lightnovel.fun $address, MAP api.lightnovel.fun $address, MAP res.lightnovel.fun $address"}}""",
+            )
+        }
         build()
     }
+
+    @Synchronized
+    private fun engineFor(route: NetworkRoute): CronetEngine =
+        engines.getOrPut(route) { createEngine(route) }
 
     override suspend fun postJson(url: String, body: String): HttpResponse {
         val response = request(url, "POST", body.toByteArray(Charsets.UTF_8))
@@ -73,24 +79,39 @@ internal class CronetHttpTransport(context: Context) : HttpTransport {
 
     private suspend fun request(url: String, method: String, upload: ByteArray?): HttpBytesResponse {
         var lastFailure: IOException? = null
-        repeat(CLOUDFLARE_ROUTES.size + 1) { attempt ->
+        NETWORK_ROUTES.forEachIndexed { index, route ->
             try {
-                return executeOnce(engine, url, method, upload)
+                return executeWithTimeout(engineFor(route), url, method, upload).also {
+                    if (index > 0) {
+                        Log.i(TAG, "${Uri.parse(url).host} connected through ${route.label}")
+                    }
+                }
             } catch (failure: IOException) {
                 lastFailure = failure
-                if (attempt == CLOUDFLARE_ROUTES.size || !failure.isRetryableConnectionFailure()) {
+                if (index == NETWORK_ROUTES.lastIndex || !failure.isRetryableConnectionFailure()) {
                     throw failure
                 }
-                rebuildEngine()
+                Log.w(
+                    TAG,
+                    "${Uri.parse(url).host} failed through ${route.label}; trying fallback",
+                    failure,
+                )
             }
         }
         throw lastFailure ?: IOException("网络连接失败")
     }
 
-    @Synchronized
-    private fun rebuildEngine() {
-        routeIndex = (routeIndex + 1) % CLOUDFLARE_ROUTES.size
-        engine = createEngine(CLOUDFLARE_ROUTES[routeIndex])
+    private suspend fun executeWithTimeout(
+        requestEngine: CronetEngine,
+        url: String,
+        method: String,
+        upload: ByteArray?,
+    ): HttpBytesResponse = try {
+        withTimeout(ROUTE_TIMEOUT_MS) {
+            executeOnce(requestEngine, url, method, upload)
+        }
+    } catch (failure: TimeoutCancellationException) {
+        throw RouteTimeoutException(failure)
     }
 
     private suspend fun executeOnce(
@@ -175,12 +196,36 @@ internal class CronetHttpTransport(context: Context) : HttpTransport {
         }
 
     private fun IOException.isRetryableConnectionFailure(): Boolean {
+        if (this is RouteTimeoutException) return true
         val cronetError = cause as? CronetException ?: return false
-        return cronetError.message.orEmpty().contains("ERR_CONNECTION_RESET") ||
-            cronetError.message.orEmpty().contains("ERR_QUIC_PROTOCOL_ERROR")
+        return RETRYABLE_NETWORK_ERRORS.any(cronetError.message.orEmpty()::contains)
     }
 
     private companion object {
-        val CLOUDFLARE_ROUTES = arrayOf("104.26.6.43", "104.26.7.43", "172.67.73.171")
+        const val TAG = "LightNovelNetwork"
+        const val ROUTE_TIMEOUT_MS = 12_000L
+
+        val NETWORK_ROUTES = listOf(
+            NetworkRoute("system DNS"),
+            NetworkRoute("legacy Cloudflare 1", "104.26.6.43"),
+            NetworkRoute("legacy Cloudflare 2", "104.26.7.43"),
+            NetworkRoute("legacy Cloudflare 3", "172.67.73.171"),
+        )
+
+        val RETRYABLE_NETWORK_ERRORS = listOf(
+            "ERR_CONNECTION_RESET",
+            "ERR_QUIC_PROTOCOL_ERROR",
+            "ERR_TIMED_OUT",
+            "ERR_NAME_NOT_RESOLVED",
+            "ERR_ADDRESS_UNREACHABLE",
+            "ERR_NETWORK_CHANGED",
+        )
     }
 }
+
+private data class NetworkRoute(
+    val label: String,
+    val address: String? = null,
+)
+
+private class RouteTimeoutException(cause: Throwable) : IOException("网络请求超时", cause)

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/core/network/JsonExt.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/core/network/JsonExt.kt
@@ -143,26 +143,31 @@ object ApiParsers {
 
     fun chapterDetail(source: JsonObject): ChapterDetail {
         val body = source.obj("body_snapshot", "body", "content")
-        val navigation = source.obj("navigation")
+        val navigation = source.obj("navigation", "chapter_navigation", "nav")
         return ChapterDetail(
             chapter = chapter(source),
             bookTitle = source.string("book_title"),
             volumeTitle = source.string("volume_title", "origin_volume_title"),
             bodyText = body?.string("body_text", "text", "content_text").orEmpty(),
             bodyHtml = body?.string("body_html", "html", "content_html").orEmpty(),
-            previousChapterId = navigation?.navigationId("prev_chapter", "previous_chapter"),
-            nextChapterId = navigation?.navigationId("next_chapter"),
+            previousChapterId = navigation?.navigationId("prev_chapter", "previous_chapter", "prev")
+                ?: source.navigationId("prev_chapter", "previous_chapter", "prev_chapter_id"),
+            nextChapterId = navigation?.navigationId("next_chapter", "next")
+                ?: source.navigationId("next_chapter", "next_chapter_id"),
         )
     }
 
     private fun JsonObject.navigationId(vararg keys: String): Long? {
         val element = element(*keys) ?: return null
-        val candidate = when (element) {
-            is JsonObject -> element
-            is JsonArray -> element.firstOrNull() as? JsonObject
-            else -> null
-        } ?: return null
-        return candidate.long("chapter_id", "id").takeIf { it > 0 }
+        return element.navigationId()
+    }
+
+    private fun JsonElement.navigationId(): Long? = when (this) {
+        is JsonPrimitive -> (longOrNull ?: contentOrNull?.toLongOrNull())?.takeIf { it > 0 }
+        is JsonObject -> long("chapter_id", "id", "chapterId").takeIf { it > 0 }
+            ?: element("chapter", "value")?.navigationId()
+        is JsonArray -> firstNotNullOfOrNull { it.navigationId() }
+        else -> null
     }
 
     fun comment(source: JsonObject): Comment {

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/feature/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/feature/reader/ReaderScreen.kt
@@ -1,10 +1,12 @@
 package io.github.jiangyuyi.lightnovel.feature.reader
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -12,33 +14,43 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -48,13 +60,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import coil.compose.SubcomposeAsyncImage
 import io.github.jiangyuyi.lightnovel.core.model.ReaderFont
 import io.github.jiangyuyi.lightnovel.core.model.ReaderMode
@@ -63,13 +82,16 @@ import io.github.jiangyuyi.lightnovel.core.model.ReaderTheme
 import io.github.jiangyuyi.lightnovel.core.ui.ErrorPane
 import io.github.jiangyuyi.lightnovel.core.ui.LoadingPane
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -> Unit) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val colors = state.preferences.readerColors()
+    val safeTopPadding = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
+    val chapterId = state.chapter?.chapter?.id
     val blocks = remember(state.chapter) {
         val chapter = state.chapter
         if (chapter == null) emptyList() else buildList {
@@ -80,6 +102,16 @@ fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -
     var anchorBlock by rememberSaveable(state.chapter?.chapter?.id) {
         mutableIntStateOf(state.restoredParagraph.coerceAtLeast(0))
     }
+    var readerPosition by remember(chapterId, state.preferences.mode) {
+        mutableStateOf(ReaderPosition(unit = if (state.preferences.mode == ReaderMode.PAGED) "页" else "段"))
+    }
+    var jumpRequest by remember(chapterId, state.preferences.mode) {
+        mutableStateOf<ReaderJumpRequest?>(null)
+    }
+    var jumpRequestToken by remember { mutableIntStateOf(0) }
+    var jumpDialogVisible by rememberSaveable(chapterId, state.preferences.mode) { mutableStateOf(false) }
+
+    ImmersiveReaderEffect(darkBackground = state.preferences.theme == ReaderTheme.DARK)
 
     LaunchedEffect(state.chapter?.chapter?.id, state.restoredParagraph) {
         anchorBlock = state.restoredParagraph.coerceAtLeast(0)
@@ -105,6 +137,10 @@ fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -
                 onNextChapter = viewModel::next,
                 hasPreviousChapter = state.chapter?.previousChapterId != null,
                 hasNextChapter = state.chapter?.nextChapterId != null,
+                safeTopPadding = safeTopPadding,
+                jumpRequest = jumpRequest,
+                onJumpConsumed = { consumed -> if (jumpRequest == consumed) jumpRequest = null },
+                onPositionChanged = { current, total -> readerPosition = ReaderPosition(current, total, "页") },
             )
             else -> ScrollingReader(
                 blocks = blocks,
@@ -114,6 +150,10 @@ fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -
                 onAnchorChanged = { anchorBlock = it },
                 onProgress = { index -> viewModel.saveProgress(index, blocks.size) },
                 onToggleControls = viewModel::toggleControls,
+                safeTopPadding = safeTopPadding,
+                jumpRequest = jumpRequest,
+                onJumpConsumed = { consumed -> if (jumpRequest == consumed) jumpRequest = null },
+                onPositionChanged = { current, total -> readerPosition = ReaderPosition(current, total, "段") },
             )
         }
 
@@ -128,6 +168,12 @@ fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -
                 onSettings = { viewModel.showSettings(true) },
                 previousEnabled = state.chapter?.previousChapterId != null,
                 nextEnabled = state.chapter?.nextChapterId != null,
+                position = readerPosition,
+                onQuickJump = { position ->
+                    jumpRequestToken += 1
+                    jumpRequest = ReaderJumpRequest(position, jumpRequestToken)
+                },
+                onShowJumpDialog = { jumpDialogVisible = true },
             )
         }
     }
@@ -137,6 +183,18 @@ fun ReaderScreen(viewModel: ReaderViewModel, onBack: () -> Unit, onCatalog: () -
             preferences = state.preferences,
             onChange = { value -> viewModel.updatePreferences { value } },
             onDismiss = { viewModel.showSettings(false) },
+        )
+    }
+
+    if (jumpDialogVisible) {
+        ReaderJumpDialog(
+            position = readerPosition,
+            onJump = { position ->
+                jumpRequestToken += 1
+                jumpRequest = ReaderJumpRequest(position, jumpRequestToken)
+                jumpDialogVisible = false
+            },
+            onDismiss = { jumpDialogVisible = false },
         )
     }
 }
@@ -154,6 +212,10 @@ private fun PagedReader(
     onNextChapter: () -> Unit,
     hasPreviousChapter: Boolean,
     hasNextChapter: Boolean,
+    safeTopPadding: Dp,
+    jumpRequest: ReaderJumpRequest?,
+    onJumpConsumed: (ReaderJumpRequest) -> Unit,
+    onPositionChanged: (Int, Int) -> Unit,
 ) {
     BoxWithConstraints(Modifier.fillMaxSize()) {
         val density = LocalDensity.current
@@ -161,8 +223,8 @@ private fun PagedReader(
         val paragraphStyle = preferences.paragraphStyle(colors.text)
         val headingStyle = preferences.headingStyle(colors.text)
         val horizontalPadding = preferences.horizontalPadding.dp
-        val pageTopPadding = 72.dp
-        val pageBottomPadding = 88.dp
+        val pageTopPadding = safeTopPadding + 8.dp
+        val pageBottomPadding = 12.dp
         val pageWidthPx = with(density) { (maxWidth - horizontalPadding * 2).roundToPx().coerceAtLeast(1) }
         val pageHeightPx = with(density) {
             (maxHeight - pageTopPadding - pageBottomPadding).roundToPx().coerceAtLeast(1)
@@ -180,8 +242,11 @@ private fun PagedReader(
                 spacingPx = spacingPx,
             )
         }
-        val pagerState = rememberPagerState { pages.size.coerceAtLeast(1) }
-        val scope = rememberCoroutineScope()
+        val pagerState = rememberPagerState {
+            pages.size.coerceAtLeast(1) + if (hasNextChapter) 1 else 0
+        }
+        var turnRequest by remember { mutableStateOf<ReaderTurnRequest?>(null) }
+        var turnRequestToken by remember { mutableIntStateOf(0) }
 
         LaunchedEffect(pages) {
             val containingPage = pages.indexOfFirst { anchorBlock in it.firstBlockIndex..it.lastBlockIndex }
@@ -190,6 +255,11 @@ private fun PagedReader(
                 .coerceAtMost(pages.lastIndex.coerceAtLeast(0))
             if (pagerState.currentPage != target) pagerState.scrollToPage(target)
         }
+        LaunchedEffect(jumpRequest?.token, pages.size) {
+            val request = jumpRequest ?: return@LaunchedEffect
+            pagerState.animateScrollToPage(request.position.coerceIn(1, pages.size) - 1)
+            onJumpConsumed(request)
+        }
         LaunchedEffect(pagerState, pages) {
             snapshotFlow { pagerState.currentPage }
                 .distinctUntilChanged()
@@ -197,58 +267,112 @@ private fun PagedReader(
                     pages.getOrNull(pageIndex)?.firstBlockIndex?.let {
                         onAnchorChanged(it)
                         onProgress(it)
+                        onPositionChanged(pageIndex + 1, pages.size.coerceAtLeast(1))
                     }
                 }
+        }
+        LaunchedEffect(pagerState.currentPage, pages.size, hasNextChapter) {
+            if (hasNextChapter && pagerState.currentPage == pages.size) onNextChapter()
+        }
+        LaunchedEffect(turnRequest?.token) {
+            val request = turnRequest ?: return@LaunchedEffect
+            when (request.direction) {
+                ReaderTurnDirection.PREVIOUS -> when {
+                    pagerState.currentPage > 0 -> pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                    hasPreviousChapter -> onPreviousChapter()
+                }
+                ReaderTurnDirection.NEXT -> when {
+                    pagerState.currentPage < pages.lastIndex -> pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                    hasNextChapter -> onNextChapter()
+                }
+            }
+            if (turnRequest == request) turnRequest = null
         }
 
         HorizontalPager(
             state = pagerState,
             beyondViewportPageCount = 1,
+            userScrollEnabled = false,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = pageTopPadding, bottom = pageBottomPadding)
-                .pointerInput(pages.size, hasPreviousChapter, hasNextChapter) {
-                    awaitEachGesture {
-                        val down = awaitFirstDown(requireUnconsumed = false)
-                        val up = waitForUpOrCancellation() ?: return@awaitEachGesture
-                        val fraction = up.position.x / size.width.toFloat().coerceAtLeast(1f)
-                        when {
-                            fraction < 0.30f && pagerState.currentPage > 0 -> scope.launch {
-                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                            }
-                            fraction < 0.30f && hasPreviousChapter -> onPreviousChapter()
-                            fraction > 0.70f && pagerState.currentPage < pages.lastIndex -> scope.launch {
-                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                            }
-                            fraction > 0.70f && hasNextChapter -> onNextChapter()
-                            else -> onToggleControls()
+                .padding(top = pageTopPadding, bottom = pageBottomPadding),
+        ) { pageIndex ->
+            if (pageIndex < pages.size) {
+                Column(
+                    modifier = Modifier.fillMaxSize().padding(horizontal = horizontalPadding),
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    pages.getOrNull(pageIndex)?.elements.orEmpty().forEach { element ->
+                        when (element) {
+                            is ReaderPageElement.Text -> ReaderTextElement(element, preferences, colors)
+                            is ReaderPageElement.Illustration -> ReaderIllustration(
+                                block = element.block,
+                                modifier = Modifier.fillMaxWidth().height(with(density) { element.heightPx.toDp() }),
+                                colors = colors,
+                            )
                         }
                     }
-                },
-        ) { pageIndex ->
-            Column(
-                modifier = Modifier.fillMaxSize().padding(horizontal = horizontalPadding),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-            ) {
-                pages.getOrNull(pageIndex)?.elements.orEmpty().forEach { element ->
-                    when (element) {
-                        is ReaderPageElement.Text -> ReaderTextElement(element, preferences, colors)
-                        is ReaderPageElement.Illustration -> ReaderIllustration(
-                            block = element.block,
-                            modifier = Modifier.fillMaxWidth().height(with(density) { element.heightPx.toDp() }),
-                            colors = colors,
-                        )
-                    }
+                }
+            } else {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("正在进入下一章…", color = colors.text.copy(alpha = 0.72f))
                 }
             }
         }
 
-        Text(
-            text = "${pagerState.currentPage + 1} / ${pages.size.coerceAtLeast(1)}",
-            color = colors.text.copy(alpha = 0.55f),
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.align(Alignment.BottomEnd).padding(end = horizontalPadding, bottom = 72.dp),
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(pages.size, hasPreviousChapter, hasNextChapter) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val start = down.position
+                        var releasedX: Float? = null
+                        var releasedY: Float? = null
+                        while (releasedX == null) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                            change.consume()
+                            if (!change.pressed) {
+                                releasedX = change.position.x
+                                releasedY = change.position.y
+                            }
+                        }
+                        val endX = releasedX ?: return@awaitEachGesture
+                        val endY = releasedY ?: return@awaitEachGesture
+                        val deltaX = endX - start.x
+                        val deltaY = endY - start.y
+                        val swipeThreshold = size.width * 0.10f
+                        val isHorizontalSwipe = abs(deltaX) >= swipeThreshold && abs(deltaX) > abs(deltaY)
+
+                        fun requestTurn(direction: ReaderTurnDirection) {
+                            turnRequestToken += 1
+                            turnRequest = ReaderTurnRequest(direction, turnRequestToken)
+                        }
+
+                        when {
+                            isHorizontalSwipe && deltaX > 0 -> requestTurn(ReaderTurnDirection.PREVIOUS)
+                            isHorizontalSwipe && deltaX < 0 -> requestTurn(ReaderTurnDirection.NEXT)
+                            abs(deltaX) <= viewConfiguration.touchSlop && abs(deltaY) <= viewConfiguration.touchSlop -> {
+                                when (endX / size.width.toFloat().coerceAtLeast(1f)) {
+                                    in 0f..0.30f -> requestTurn(ReaderTurnDirection.PREVIOUS)
+                                    in 0.70f..1f -> requestTurn(ReaderTurnDirection.NEXT)
+                                    else -> onToggleControls()
+                                }
+                            }
+                        }
+                    }
+                },
         )
+
+        if (pagerState.currentPage < pages.size) {
+            Text(
+                text = "${pagerState.currentPage + 1} / ${pages.size.coerceAtLeast(1)}",
+                color = colors.text.copy(alpha = 0.55f),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 4.dp),
+            )
+        }
     }
 }
 
@@ -261,12 +385,23 @@ private fun ScrollingReader(
     onAnchorChanged: (Int) -> Unit,
     onProgress: (Int) -> Unit,
     onToggleControls: () -> Unit,
+    safeTopPadding: Dp,
+    jumpRequest: ReaderJumpRequest?,
+    onJumpConsumed: (ReaderJumpRequest) -> Unit,
+    onPositionChanged: (Int, Int) -> Unit,
 ) {
     val listState = rememberLazyListState()
-    LaunchedEffect(blocks, anchorBlock) {
+    LaunchedEffect(blocks) {
         if (blocks.isNotEmpty() && listState.firstVisibleItemIndex == 0) {
             listState.scrollToItem(anchorBlock.coerceIn(0, blocks.lastIndex))
         }
+    }
+    LaunchedEffect(jumpRequest?.token, blocks.size) {
+        val request = jumpRequest ?: return@LaunchedEffect
+        if (blocks.isNotEmpty()) {
+            listState.animateScrollToItem(request.position.coerceIn(1, blocks.size) - 1)
+        }
+        onJumpConsumed(request)
     }
     LaunchedEffect(listState, blocks.size) {
         snapshotFlow { listState.firstVisibleItemIndex }
@@ -274,17 +409,28 @@ private fun ScrollingReader(
             .collect {
                 onAnchorChanged(it)
                 onProgress(it)
+                onPositionChanged(it + 1, blocks.size.coerceAtLeast(1))
             }
     }
 
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize().clickable(onClick = onToggleControls),
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(onToggleControls) {
+                detectTapGestures { position ->
+                    val horizontalFraction = position.x / size.width.toFloat().coerceAtLeast(1f)
+                    val verticalFraction = position.y / size.height.toFloat().coerceAtLeast(1f)
+                    if (horizontalFraction in 0.30f..0.70f && verticalFraction in 0.25f..0.75f) {
+                        onToggleControls()
+                    }
+                }
+            },
         contentPadding = PaddingValues(
             start = preferences.horizontalPadding.dp,
             end = preferences.horizontalPadding.dp,
-            top = 88.dp,
-            bottom = 96.dp,
+            top = safeTopPadding + 8.dp,
+            bottom = 12.dp,
         ),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
@@ -346,13 +492,19 @@ private fun BoxScope.ReaderControls(
     onSettings: () -> Unit,
     previousEnabled: Boolean,
     nextEnabled: Boolean,
+    position: ReaderPosition,
+    onQuickJump: (Int) -> Unit,
+    onShowJumpDialog: () -> Unit,
 ) {
+    var sliderValue by remember(position.current, position.total) {
+        mutableFloatStateOf(position.current.toFloat())
+    }
     TopAppBar(
         title = { Text(bookTitle) },
         navigationIcon = { TextButton(onClick = onBack) { Text("返回") } },
         actions = { TextButton(onClick = onCatalog) { Text("目录") } },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = colors.background,
+            containerColor = colors.background.copy(alpha = 0.97f),
             titleContentColor = colors.text,
             navigationIconContentColor = colors.text,
             actionIconContentColor = colors.text,
@@ -360,19 +512,71 @@ private fun BoxScope.ReaderControls(
     )
     Surface(
         modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
-        color = colors.background,
+        color = colors.background.copy(alpha = 0.97f),
         tonalElevation = 4.dp,
+        shadowElevation = 8.dp,
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(10.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            TextButton(onClick = onPrevious, enabled = previousEnabled) { Text("上一章") }
-            Button(onClick = onSettings) { Text("阅读设置") }
-            TextButton(onClick = onNext, enabled = nextEnabled) { Text("下一章") }
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 8.dp, top = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Slider(
+                    value = sliderValue.coerceIn(1f, position.total.coerceAtLeast(2).toFloat()),
+                    onValueChange = { sliderValue = it },
+                    onValueChangeFinished = { onQuickJump(sliderValue.roundToInt()) },
+                    valueRange = 1f..position.total.coerceAtLeast(2).toFloat(),
+                    enabled = position.total > 1,
+                    colors = readerSliderColors(),
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onShowJumpDialog) {
+                    Text("${position.current}/${position.total}${position.unit}", color = colors.text)
+                }
+            }
+            HorizontalDivider(color = colors.text.copy(alpha = 0.12f))
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onPrevious, enabled = previousEnabled) { Text("上一章") }
+                Button(onClick = onSettings) { Text("阅读设置") }
+                TextButton(onClick = onNext, enabled = nextEnabled) { Text("下一章") }
+            }
         }
     }
+}
+
+@Composable
+private fun ReaderJumpDialog(
+    position: ReaderPosition,
+    onJump: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var input by remember(position.current, position.total) { mutableStateOf(position.current.toString()) }
+    val target = input.toIntOrNull()?.takeIf { it in 1..position.total.coerceAtLeast(1) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (position.unit == "页") "跳转页码" else "快速定位") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { value -> input = value.filter(Char::isDigit).take(6) },
+                    label = { Text("${position.unit}码") },
+                    supportingText = { Text("可输入 1 到 ${position.total}") },
+                    isError = input.isNotEmpty() && target == null,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { target?.let(onJump) }, enabled = target != null) { Text("跳转") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } },
+    )
 }
 
 @Composable
@@ -390,20 +594,20 @@ private fun ReaderSettingsDialog(
                 Text("翻页方式")
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     ReaderMode.entries.forEach { mode ->
-                        FilterChip(
+                        ReaderOptionChip(
                             selected = preferences.mode == mode,
                             onClick = { onChange(preferences.copy(mode = mode)) },
-                            label = { Text(mode.label) },
+                            label = mode.label,
                         )
                     }
                 }
                 Text("字体")
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     ReaderFont.entries.forEach { font ->
-                        FilterChip(
+                        ReaderOptionChip(
                             selected = preferences.font == font,
                             onClick = { onChange(preferences.copy(font = font)) },
-                            label = { Text(font.label) },
+                            label = font.label,
                         )
                     }
                 }
@@ -413,6 +617,7 @@ private fun ReaderSettingsDialog(
                     onValueChange = { onChange(preferences.copy(fontSize = it)) },
                     valueRange = 14f..32f,
                     steps = 17,
+                    colors = readerSliderColors(),
                 )
                 Text("行高 ${"%.1f".format(preferences.lineHeight)}")
                 Slider(
@@ -420,6 +625,7 @@ private fun ReaderSettingsDialog(
                     onValueChange = { onChange(preferences.copy(lineHeight = it)) },
                     valueRange = 1.2f..2.2f,
                     steps = 9,
+                    colors = readerSliderColors(),
                 )
                 Text("页边距 ${preferences.horizontalPadding}")
                 Slider(
@@ -427,15 +633,16 @@ private fun ReaderSettingsDialog(
                     onValueChange = { onChange(preferences.copy(horizontalPadding = it.toInt())) },
                     valueRange = 12f..40f,
                     steps = 13,
+                    colors = readerSliderColors(),
                 )
                 Text("背景")
                 ReaderTheme.entries.chunked(2).forEach { row ->
                     Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                         row.forEach { theme ->
-                            FilterChip(
+                            ReaderOptionChip(
                                 selected = preferences.theme == theme,
                                 onClick = { onChange(preferences.copy(theme = theme)) },
-                                label = { Text(theme.label) },
+                                label = theme.label,
                             )
                         }
                     }
@@ -444,6 +651,70 @@ private fun ReaderSettingsDialog(
         },
     )
 }
+
+@Composable
+private fun ReaderOptionChip(selected: Boolean, onClick: () -> Unit, label: String) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label, fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal) },
+        leadingIcon = if (selected) {
+            { Text("✓", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold) }
+        } else {
+            null
+        },
+        colors = FilterChipDefaults.filterChipColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            selectedContainerColor = MaterialTheme.colorScheme.primary,
+            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+            selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+    )
+}
+
+@Composable
+private fun readerSliderColors() = SliderDefaults.colors(
+    thumbColor = MaterialTheme.colorScheme.primary,
+    activeTrackColor = MaterialTheme.colorScheme.primary,
+    inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+)
+
+@Composable
+private fun ImmersiveReaderEffect(darkBackground: Boolean) {
+    val view = LocalView.current
+    DisposableEffect(view, darkBackground) {
+        val window = view.context.findActivity()?.window
+        val controller = window?.let { WindowCompat.getInsetsController(it, view) }
+        val previousLightStatusBars = controller?.isAppearanceLightStatusBars
+        controller?.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        controller?.show(WindowInsetsCompat.Type.statusBars())
+        controller?.hide(WindowInsetsCompat.Type.navigationBars())
+        controller?.isAppearanceLightStatusBars = !darkBackground
+        onDispose {
+            controller?.show(WindowInsetsCompat.Type.systemBars())
+            previousLightStatusBars?.let { controller?.isAppearanceLightStatusBars = it }
+        }
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private data class ReaderPosition(
+    val current: Int = 1,
+    val total: Int = 1,
+    val unit: String,
+)
+
+private data class ReaderJumpRequest(val position: Int, val token: Int)
+
+private enum class ReaderTurnDirection { PREVIOUS, NEXT }
+
+private data class ReaderTurnRequest(val direction: ReaderTurnDirection, val token: Int)
 
 private data class ReaderColors(val background: Color, val text: Color)
 

--- a/app/src/main/java/io/github/jiangyuyi/lightnovel/feature/reader/ReaderViewModel.kt
+++ b/app/src/main/java/io/github/jiangyuyi/lightnovel/feature/reader/ReaderViewModel.kt
@@ -19,7 +19,7 @@ data class ReaderState(
     val chapter: ChapterDetail? = null,
     val preferences: ReaderPreferences = ReaderPreferences(),
     val restoredParagraph: Int = 0,
-    val controlsVisible: Boolean = true,
+    val controlsVisible: Boolean = false,
     val settingsVisible: Boolean = false,
     val loading: Boolean = true,
     val error: String? = null,
@@ -34,6 +34,7 @@ class ReaderViewModel(
     private val _state = MutableStateFlow(ReaderState())
     val state: StateFlow<ReaderState> = _state.asStateFlow()
     private var currentChapterId = initialChapterId
+    private var chapterLoadJob: Job? = null
     private var progressJob: Job? = null
     private var settingsSyncJob: Job? = null
 
@@ -48,19 +49,29 @@ class ReaderViewModel(
 
     fun loadChapter(chapterId: Long) {
         if (chapterId <= 0) return
+        chapterLoadJob?.cancel()
+        progressJob?.cancel()
         currentChapterId = chapterId
-        _state.value = _state.value.copy(loading = true, error = null, settingsVisible = false)
-        viewModelScope.launch {
+        _state.value = _state.value.copy(
+            loading = true,
+            error = null,
+            settingsVisible = false,
+            controlsVisible = false,
+        )
+        chapterLoadJob = viewModelScope.launch {
             val progress = preferenceStore.progress(bookId).first()
             runCatching { repository.chapter(bookId, chapterId) }
                 .onSuccess { chapter ->
+                    if (currentChapterId != chapterId) return@onSuccess
                     _state.value = _state.value.copy(
                         chapter = chapter,
                         restoredParagraph = progress?.takeIf { it.chapterId == chapterId }?.paragraphIndex ?: 0,
                         loading = false,
+                        controlsVisible = false,
                     )
                 }
                 .onFailure {
+                    if (currentChapterId != chapterId) return@onFailure
                     _state.value = _state.value.copy(loading = false, error = it.message ?: "章节加载失败")
                 }
         }

--- a/app/src/test/java/io/github/jiangyuyi/lightnovel/core/data/ChapterNavigationTest.kt
+++ b/app/src/test/java/io/github/jiangyuyi/lightnovel/core/data/ChapterNavigationTest.kt
@@ -1,0 +1,46 @@
+package io.github.jiangyuyi.lightnovel.core.data
+
+import io.github.jiangyuyi.lightnovel.core.model.ChapterSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChapterNavigationTest {
+    private val chapters = listOf(
+        chapter(317743, 1),
+        chapter(316297, 2),
+        chapter(317744, 3),
+    )
+
+    @Test
+    fun `resolves both neighbors for a middle chapter`() {
+        val neighbors = resolveChapterNeighbors(chapters, 316297)
+
+        assertEquals(317743L, neighbors?.previousChapterId)
+        assertEquals(317744L, neighbors?.nextChapterId)
+    }
+
+    @Test
+    fun `keeps missing side null at volume boundary`() {
+        val first = resolveChapterNeighbors(chapters, 317743)
+        val last = resolveChapterNeighbors(chapters, 317744)
+
+        assertNull(first?.previousChapterId)
+        assertEquals(316297L, first?.nextChapterId)
+        assertEquals(316297L, last?.previousChapterId)
+        assertNull(last?.nextChapterId)
+    }
+
+    @Test
+    fun `returns null when current chapter is absent`() {
+        assertNull(resolveChapterNeighbors(chapters, 999999))
+    }
+
+    private fun chapter(id: Long, order: Int) = ChapterSummary(
+        id = id,
+        bookId = 11950,
+        volumeId = 13121,
+        title = "第 $order 章",
+        order = order,
+    )
+}

--- a/app/src/test/java/io/github/jiangyuyi/lightnovel/core/network/ApiParsersTest.kt
+++ b/app/src/test/java/io/github/jiangyuyi/lightnovel/core/network/ApiParsersTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -93,6 +94,45 @@ class ApiParsersTest {
     }
 
     @Test
+    fun `chapter parser accepts live object navigation and direct ids`() {
+        val liveObject = ApiParsers.chapterDetail(
+            obj(
+                """
+                {
+                  "chapter_id": 317743,
+                  "book_id": 11950,
+                  "volume_id": 13121,
+                  "title": "序章",
+                  "navigation": {
+                    "prev_chapter": [],
+                    "next_chapter": {"chapter_id": 316297}
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+        val directIds = ApiParsers.chapterDetail(
+            obj(
+                """
+                {
+                  "chapter_id": 20,
+                  "book_id": 1,
+                  "volume_id": 2,
+                  "title": "第二章",
+                  "prev_chapter_id": "19",
+                  "next_chapter_id": 21
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertNull(liveObject.previousChapterId)
+        assertEquals(316297L, liveObject.nextChapterId)
+        assertEquals(19L, directIds.previousChapterId)
+        assertEquals(21L, directIds.nextChapterId)
+    }
+
+    @Test
     fun `taxonomy parser keeps channels and nested tags`() {
         val source = obj(
             """
@@ -119,4 +159,3 @@ class ApiParsersTest {
 
     private fun obj(raw: String): JsonObject = json.parseToJsonElement(raw) as JsonObject
 }
-


### PR DESCRIPTION
## 变更内容

- 将应用默认版本更新为 1.0.2（versionCode 3）。
- 阅读界面改为沉浸式分页阅读：控制栏默认隐藏、中央点击显示、页码居中并适配刘海/挖孔和大圆角安全区。
- 修复上一章、下一章以及跨卷章节导航；章节末页继续翻页可直接进入下一章。
- 增加页码输入、快速进度滑动，并增强阅读设置选中状态的视觉区分。
- 修复封面与正文插画加载：每个请求优先使用系统 DNS，并独立回退到旧 Cloudflare 路线，增加超时和可重试网络错误处理。
- 新增 Android PR CI，在 PR 和 main 推送时运行单元测试、Lint 与 Debug APK 构建。
- 将 Release 工作流和 README 的示例版本同步为 v1.0.2。

## 原因

站点部分章节响应缺少完整的相邻章节导航数据，导致上一章/下一章按钮失效。图片网络层原先使用可被并发请求共同修改的全局固定路由，CDN 线路发生变化或连接重置后，封面和插画会长时间停留在加载状态。

## 用户影响

阅读内容可充分利用安全显示区域，支持直接分页和快速跳页；章节边界不再打断连续阅读；封面和插画在当前真机网络环境下可可靠回退并重新下载。

## 验证

- `./gradlew testDebugUnitTest lintDebug assembleDebug --no-daemon "-Pkotlin.incremental=false"`
- 15 项单元测试通过，Android Lint 通过，Debug 构建成功。
- APK 元数据：`versionCode=3`，`versionName=1.0.2`。
- 真机清空图片缓存后验证榜单/详情封面和正文插画可重新下载显示。
- 真机验证上一章、下一章、章节末页自动进入下一章、页码输入和阅读设置。